### PR TITLE
Feature/wang dataset

### DIFF
--- a/src/preprocess_metadata_functions.py
+++ b/src/preprocess_metadata_functions.py
@@ -250,10 +250,14 @@ def preprocess_wang():
     #df["dnase"]="No"
     df["library_prep_kit"] = "SLiPiR-seq"
     df["library_prep_kit_short"] = "SLiPiR-seq"
-    # There are 3 samples that were processed with a different library prep kit
+
+    # There are 3 samples that were processed with a different library prep kit.
+    # Discard them.
     index = df[df['Sample Name'].str.startswith("NEB")].index
     df.loc[index, "library_prep_kit"] = "NEBNext Small RNA Library Prep Set"
     df.loc[index, "library_prep_kit_short"] = "NEBNext"
+    df = df.loc[df.index.difference(index)]
+
     def parse_plasma_volume_wang(s):
         m = re.search(r'^Input\(([\d.]+?)\).*$', s, re.I)
         if m:
@@ -262,6 +266,7 @@ def preprocess_wang():
             return np.nan
 
     df['plasma_volume'] = df['Sample Name'].map(parse_plasma_volume_wang).dropna()
+    
     # During technology optimization, different modifications of the library prep
     # protocol were tested. We discard the samples for which irrelevant modifications
     # were applied to the protocol, such as removing the ExoI enzyme or changing


### PR DESCRIPTION
See also notes in [Asana](https://app.asana.com/1/311741935750741/project/1200831694404739/task/1210027820393365?focus=true).

There are 3 samples that were processed using the NEBNext library prep kit, with "Sample Name" NEB-1, NEB-2, and NEB-3 in SRA. Should we include or exclude them from the meta-analysis? The library kit name was corrected for these 3 samples in the preprocess_metadata_functions.py script (see preprocess_wang()  function).

I parsed the plasma volume from the technology optimization samples: "different input plasma volumes (12.5 μl, 25 μl, 50 μl, 100 μl, 200 μl, and 400 μl)".

For the meta-analysis, I would suggest to only include the samples with the optimized protocol, i.e. 1) with ExoI and USER enzymes, and 2) final concentration of RT primer of 5 nM. These variables are specific to the SLiPiR-seq protocol and irrelevant to other methods. I have **discarded these samples** in the preprocess_wang()  function.